### PR TITLE
BUGFIX (definitive) for regex search matching deleted text

### DIFF
--- a/scintilla/Scintilla.vcxproj
+++ b/scintilla/Scintilla.vcxproj
@@ -102,7 +102,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <Optimization>Disabled</Optimization>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <PreprocessorDefinitions>X_SCINTILLA_RANGEGAP_FIX;JRB_BUILD;SCI_NAMESPACE;NO_CXX11_REGEX;SCI_OWNREGEX;ONIG_EXTERN=extern;_WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_DEPRECATE;_SCL_SECURE_NO_WARNINGS;STATIC_BUILD;SCI_LEXER;USE_D2D;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>JRB_BUILD;SCI_NAMESPACE;NO_CXX11_REGEX;SCI_OWNREGEX;ONIG_EXTERN=extern;_WIN64;_DEBUG;_WINDOWS;_CRT_SECURE_NO_DEPRECATE;_SCL_SECURE_NO_WARNINGS;STATIC_BUILD;SCI_LEXER;USE_D2D;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>

--- a/scintilla/src/CellBuffer.cxx
+++ b/scintilla/src/CellBuffer.cxx
@@ -598,12 +598,6 @@ const char *CellBuffer::RangePointer(Sci::Position position, Sci::Position range
 	return substance.RangePointer(position, rangeLength);
 }
 
-#ifdef X_SCINTILLA_RANGEGAP_FIX
-const char *CellBuffer::DataPointer(Sci::Position position, Sci::Position rangeLength) {
-	return substance.DataPointer(position, rangeLength);
-}
-
-#endif
 Sci::Position CellBuffer::GapPosition() const noexcept {
 	return substance.GapPosition();
 }

--- a/scintilla/src/CellBuffer.h
+++ b/scintilla/src/CellBuffer.h
@@ -150,9 +150,6 @@ public:
 	void GetStyleRange(unsigned char *buffer, Sci::Position position, Sci::Position lengthRetrieve) const;
 	const char *BufferPointer();
 	const char *RangePointer(Sci::Position position, Sci::Position rangeLength);
-#ifdef X_SCINTILLA_RANGEGAP_FIX
-	const char *DataPointer(Sci::Position position, Sci::Position rangeLength);
-#endif
 	Sci::Position GapPosition() const noexcept;
 
 	Sci::Position Length() const noexcept;

--- a/scintilla/src/Document.h
+++ b/scintilla/src/Document.h
@@ -377,11 +377,7 @@ public:
 	const char * SCI_METHOD BufferPointer() override { return cb.BufferPointer(); }
     std::string SCI_METHOD GetRegexLastError() { return regex->GetErrorInfo(); }
 
-#ifdef X_SCINTILLA_RANGEGAP_FIX
-	const char *RangePointer(Sci::Position position, Sci::Position rangeLength) { return cb.DataPointer(position, rangeLength); }
-#else // !X_SCINTILLA_RANGEGAP_FIX
 	const char *RangePointer(Sci::Position position, Sci::Position rangeLength) { return cb.RangePointer(position, rangeLength); }
-#endif
 	Sci::Position GapPosition() const { return cb.GapPosition(); }
 
 	int SCI_METHOD GetLineIndentation(Sci_Position line) override;

--- a/scintilla/src/SplitVector.h
+++ b/scintilla/src/SplitVector.h
@@ -321,41 +321,6 @@ public:
 		}
 	}
 
-#ifdef X_SCINTILLA_RANGEGAP_FIX
-	/// Return a pointer to a range of elements *excluding* the gap, while still
-	/// rearranging the buffer to make that range contiguous.
-	/// If the pointer is to end up at or past the end of the data (i.e. within
-	/// the gap once it's been pushed after all elements), the position returned
-	/// will be the end of the data block, never past it.
-	T *DataPointer(ptrdiff_t position, ptrdiff_t rangeLength) noexcept {
-		if (position >= part1Length) {
-			// Furthest position is at the end of the contiguous
-			// data block
-			return body.data() + part1Length;
-		} else { // position < part1Length
-			// Check if we have a contiguous data block of
-			// covering the whole range
-			// (i.e. from [position .. position + rangeLength] )
-			if ((position + rangeLength) > part1Length) {
-				// Range overlaps gap, so move gap to *end* of range.
-				// (i.e. moving the gap past position + rangeLength)
-				GapTo(position + rangeLength);
-				// Now, part1Length might have changed;
-				// check if we still go over
-				if (position > part1Length) {
-					// Return furthest position possible
-					return body.data() + part1Length;
-				} else {
-					// We're good now
-					return body.data() + position;
-				}
-			} else {
-				return body.data() + position;
-			}
-		}
-	}
-
-#endif
 	/// Return the position of the gap within the buffer.
 	ptrdiff_t GapPosition() const noexcept {
 		return part1Length;


### PR DESCRIPTION
Reverts the bug-fixing workaround introduced as part of commit f7515375f9d0d43eebca6997becaa2192ee0565b that required to modify Scintilla's own code base by adding new members to the `Scintilla::Document()`, `Scintilla::CellBuffer()` & `Scintilla::SplitVector()` class.

### Quick recap on the bug

The bug arose from the need to plug the new regular expression engine, [Onigmo](https://github.com/k-takata/Onigmo/), into Scintilla's built-in [RegexSearchBase](https://scintilla.org/ScintillaDoc.html#AlternativeRegEx) interface for its use as a custom regex engine. While the Onimo engine expects to have direct access to a text buffer to search from, Scintilla can provide such access but care must be taken as Scintilla, internally, uses a [gap buffer](https://en.wikipedia.org/wiki/Gap_buffer) and its location must be considered when reading characters from it, as it can lead to false positives when searching for regex matches, although in very specific, edge cases.

For example, if characters were to be suppressed from the end of an existing using the `<Backspace>` key, then searching with regex pattern that would otherwise have captured both those suppressed characters—but *not*, incidentally and in such very specific cases, that same end of line without those now-suppressed chars—would effectively find a _match_ for that end of line, erroneously, simply because those suppressed chars remain in Scintilla's gap buffer until their effective removal is triggered by moving the insertion cursor elsewhere of until the text is changed elsewhere in the open document.

The original solution was to patch Scintilla's own code directly by cloning the existing `CellBuffer::RangePointer()` into a new method, `CellBuffer::DataPointer()` (as well as for its analog on the Document interface) , with the difference that that new method would actively move the buffer gap out of the way / at the end of the range specified in the method call, such that the pointer returned would *always* be for a contiguous block of text.

Although negating the performance benefit of having a buffer gap (but with the penalty only occurring when initiating a search), the real problem with the original fix is that it changed directly Scintilla's code, and as such any in-place upgrade of Scintilla is « impossible » (i.e. causes a regression of the bug) unless the fix is replicated on Scintilla's updated codebase, if it can be at all.

### The definitive fix of the bug

The need for updating Scintilla's code is pretty much a given, for the simple reason that doing so fixes many other bugs but also patches known security vulnerabilities. While contemplating such update, finding a more permanent fix (or workaround) for the bug became a priority.